### PR TITLE
Optimize Rust comparison function (20% faster overall)

### DIFF
--- a/src/script_rs/src/main.rs
+++ b/src/script_rs/src/main.rs
@@ -17,7 +17,11 @@ fn f(n: i32, m: i32) -> f64 {
 
     for _ in 0..m {
         rng.fill(&mut x[..]);
-        x.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        x.sort_unstable_by(|a, b| if a < b {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        });
         y += dotindex(&x);
     }
     let n = n as f64;


### PR DESCRIPTION
Don't know 100% if we want to this. Kind of relying on internal details of the sorting implementation here. However, since this a sorting benchmark I think it makes sense as then the benchmark is focusing of the sorting algorithm.

If the sorting benchmark used something with complete ordering like u64s this wouldn't be a problem. 

The perf boost is from avoiding the unwrap which does an extra check for NaNs.

2 Observations:

1. Internally `sort_unstable_by` just calls: `sort::quicksort(self, |a, b| compare(a, b) == Ordering::Less);` So we really only need to check for less than.

2. Since we have constructed the floats above we don't have to worry about NaNs.